### PR TITLE
Incoming breakage: Remove unnecessary `?Sized` bounds

### DIFF
--- a/src/desc/query/generic.rs
+++ b/src/desc/query/generic.rs
@@ -43,7 +43,7 @@ impl<Querier: ReuseAdvice + ?Sized> ReuseAdvice for &mut Querier {
     type ShouldReuse = Querier::ShouldReuse;
 }
 
-impl<Ptr: Deref<Target: ReuseAdvice + ?Sized>> ReuseAdvice for Pin<Ptr> {
+impl<Ptr: Deref<Target: ReuseAdvice>> ReuseAdvice for Pin<Ptr> {
     type ShouldReuse = <Ptr::Target as ReuseAdvice>::ShouldReuse;
 }
 

--- a/src/srcinfo/query/generic.rs
+++ b/src/srcinfo/query/generic.rs
@@ -52,7 +52,7 @@ impl<Querier: ReuseAdvice + ?Sized> ReuseAdvice for &mut Querier {
     type ShouldReuse = Querier::ShouldReuse;
 }
 
-impl<Ptr: Deref<Target: ReuseAdvice + ?Sized>> ReuseAdvice for Pin<Ptr> {
+impl<Ptr: Deref<Target: ReuseAdvice>> ReuseAdvice for Pin<Ptr> {
     type ShouldReuse = <Ptr::Target as ReuseAdvice>::ShouldReuse;
 }
 


### PR DESCRIPTION
Hello there :wave:, I'm a member of the Rust compiler team.

`?Sized` bounds in associated type bounds don't have any effect. The bound `Deref<Target: ReuseAdvice + ?Sized>` can simply be replaced with `Deref<Target: ReuseAdvice>` without any change in semantics.

It's a bug in the current version of the Rust compiler that writing `TraitRef<AssocTy: ?Sized>` is allowed, it should've been forbidden all along. See also https://github.com/rust-lang/rust/issues/135229. The compiler bug is about to be fixed (https://github.com/rust-lang/rust/pull/135331) and **these relaxed bounds will soon become a hard error in this position**! I sincerely apologize for the inconvenience!

---

This future breakage was found with the help of [crater](https://github.com/rust-lang/crater) (see the [build log](https://crater-reports.s3.amazonaws.com/pr-135331-1/try%2329194e8f603400afdb2f86c9418e9fccb1628ea0/gh/KSXGitHub.parse-arch-pkg-desc/log.txt)). 